### PR TITLE
Remove numpy dependency

### DIFF
--- a/nvidia_co2/constants.py
+++ b/nvidia_co2/constants.py
@@ -2,7 +2,6 @@
 # modified slightly to decrease dependencies
 
 import os
-import numpy as np
 import json
 from shapely.geometry import shape
 


### PR DESCRIPTION
This removes a superfluous numpy import so it works without installing numpy.